### PR TITLE
CI: Move preflight checks to pull_request

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,7 +1,7 @@
 name: Qualcomm Preflight Checks
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
   push:
     branches: [ master ]
@@ -15,4 +15,4 @@ jobs:
   qcom-preflight-checks:
     uses: Audioreach/audioreach-workflows/.github/workflows/qcom-preflight-checks.yml@master
     with:
-      semgrep: false
+      enable-semgrep-scan: false


### PR DESCRIPTION
Switch the preflight workflow trigger from pull_request_target to pull_request to align with the updated preflight-check orchestrator introduced in [1]. Also update the workflow input to use the new enable-semgrep-scan flag.

[1] AudioReach/audioreach-workflows#34