### PR TITLE
Disable ARMOR checkers in the Qualcomm preflight workflow

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -16,3 +16,4 @@ jobs:
     uses: Audioreach/audioreach-workflows/.github/workflows/qcom-preflight-checks.yml@master
     with:
       enable-semgrep-scan: false
+      enable-armor-checkers: false


### PR DESCRIPTION
Avoid running ARMOR validation on this repository because it contains documentation only and does not require source code analysis by ARMOR checkers.