### PR TITLE
audioreach.github.io: move to audioreach-doc@8127b51

### DIFF
--- a/docs/_sources/platform/raspberry_pi4.rst.txt
+++ b/docs/_sources/platform/raspberry_pi4.rst.txt
@@ -118,7 +118,7 @@ The AudioReach meta layer contains necessary build recipes for AudioReach. Clone
    .. code-block:: bash
 
       cd <yocto_build_root>/sources
-      git clone https://github.com/Audioreach/meta-audioreach.git
+      git clone https://github.com/Audioreach/meta-audioreach.git -b scarthgap
 	  
 Now navigate to the file "<yocto_build_root>/build/conf/bblayers.conf", and under the **BBLAYERS ?= " \\** section, append the below line to integrate the AudioReach meta layer:
 

--- a/docs/platform/raspberry_pi4.html
+++ b/docs/platform/raspberry_pi4.html
@@ -216,7 +216,7 @@ Please ensure that all utilities required for Yocto scarthgap builds meet the mi
 <p>The AudioReach meta layer contains necessary build recipes for AudioReach. Clone the meta-audioreach repository into the “sources” folder:</p>
 <blockquote>
 <div><div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">cd</span><span class="w"> </span>&lt;yocto_build_root&gt;/sources
-git<span class="w"> </span>clone<span class="w"> </span>https://github.com/Audioreach/meta-audioreach.git
+git<span class="w"> </span>clone<span class="w"> </span>https://github.com/Audioreach/meta-audioreach.git<span class="w"> </span>-b<span class="w"> </span>scarthgap
 </pre></div>
 </div>
 </div></blockquote>


### PR DESCRIPTION
Change included from audioreach-doc:
+ a36ce52 doc: rpi4: pin meta-audioreach clone to scarthgap branch